### PR TITLE
Add HumanStuff.version

### DIFF
--- a/GameData/HumanStuff/HumanStuff.version
+++ b/GameData/HumanStuff/HumanStuff.version
@@ -1,0 +1,22 @@
+{
+  "NAME": "HumanStuff",
+  "DOWNLOAD": "https://spacedock.info/mod/2524/HumanStuff",
+  "URL": "https://github.com/aazard/HumanStuff/raw/master/GameData/HumanStuff/HumanStuff.version",
+  "GITHUB": {
+    "USERNAME": "aazard",
+    "REPOSITORY": "HumanStuff"
+  },
+  "VERSION": {
+    "MAJOR": 1,
+    "MINOR": 0,
+    "PATCH": 4
+  },
+  "KSP_VERSION_MIN": {
+    "MAJOR": 1,
+    "MINOR": 8
+  },
+  "KSP_VERSION_MAX": {
+    "MAJOR": 1,
+    "MINOR": 10
+  }
+}


### PR DESCRIPTION
See [this comment](https://forum.kerbalspaceprogram.com/index.php?/topic/196759-humanstuff-slightly-more-realistic-spacesuits-heads-staff-for-ksp-v181/&do=findComment&comment=3856438) of me.

I've decided to take the work off your hands.

This is a version file as defined by AVC in its [schema](https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/master/KSP-AVC.schema.json).
If you decide to include this and create a new release afterwards, CKAN can make use of it to fetch broader compatibility information than SpaceDock allows to enter.
Users that have AVC or MiniAVC installed can also make use of this to check for mod updates.

Some things to consider:
* The file needs to be included in the released zip to work.
* Before you release a new version, please update the `VERSION` field in this file, as well as `KSP_VERSION_MIN` and `KSP_VERSION_MAX` if needed.
* You can update the compatibility information of a already released version in retrospect - e.g. if KSP 1.11 drops and you determine that the latest version does not need any changes to work. Simply change `KSP_VERSION_MIN/MAX` in this file (but keep `VERSION` the same) and push it to this repo, and both CKAN (thanks to the NetKAN bot) as well as AVC users will see this.
* If you move this file somewhere else inside this repo, please update the `URL` property. It is needed to make the above feature work.
* If you need a tool that validates this file to avoid syntax errors and the like, take a look at the [AVC-VersionFilevalidator](https://github.com/DasSkelett/AVC-VersionFileValidator). I can also help you set up that one if you want.